### PR TITLE
fix Cookie export error.

### DIFF
--- a/background.js
+++ b/background.js
@@ -94,7 +94,7 @@ function aria2Send(link,url){
             format_cookies.push(cookie.name +"="+cookie.value);
         }
         var header=[];
-        header.push("Cookie: " + format_cookies.join(";"));
+        header.push("Cookie: " + format_cookies.join("; "));
         header.push("User-Agent: " + navigator.userAgent);
         header.push("Connection: keep-alive");
         var rpc_data = {


### PR DESCRIPTION
分隔符有空格才是标准的格式，在百度网盘上，没有空格会导致不认Cookie。。。